### PR TITLE
Change the calculation of delay time

### DIFF
--- a/capture.go
+++ b/capture.go
@@ -33,7 +33,8 @@ func init() {
 func (g *GifGenerator) Capture(state *terminal.State) (paletted *image.Paletted, err error) {
 	fb := font.Bounds(fontSize)
 	cursorX, cursorY := state.Cursor()
-	paletted = image.NewPaletted(image.Rect(0, 0, g.Col*int(fb.Max.X-fb.Min.X)+10, g.Row*int(fb.Max.Y-fb.Min.Y)+10), palette.WebSafe)
+	left, top, right, bottom := g.ScreenInfo.GetRedrawRange(g.Col, g.Row, state)
+	paletted = image.NewPaletted(image.Rect(left*int(fb.Max.X-fb.Min.X), top*int(fb.Max.Y-fb.Min.Y), right*int(fb.Max.X-fb.Min.X)+10, bottom*int(fb.Max.Y-fb.Min.Y)+10), palette.WebSafe)
 
 	c := freetype.NewContext()
 	c.SetFontSize(fontSize)

--- a/generator.go
+++ b/generator.go
@@ -11,19 +11,21 @@ import (
 
 // GifGenerator type
 type GifGenerator struct {
-	Speed  float64
-	Col    int
-	Row    int
-	NoLoop bool
+	Speed      float64
+	Col        int
+	Row        int
+	NoLoop     bool
+	ScreenInfo *ScreenInfo
 }
 
 // NewGifGenerator returns GifGenerator instance
 func NewGifGenerator() *GifGenerator {
 	return &GifGenerator{
-		Speed:  1.0,
-		Col:    80,
-		Row:    24,
-		NoLoop: false,
+		Speed:      1.0,
+		Col:        80,
+		Row:        24,
+		NoLoop:     false,
+		ScreenInfo: NewScreenInfo(),
 	}
 }
 

--- a/generator.go
+++ b/generator.go
@@ -40,11 +40,15 @@ func (g *GifGenerator) Generate(input string, output string) (err error) {
 
 	// play and capture
 	var (
-		images []*image.Paletted
-		delays []int
+		images  []*image.Paletted
+		delays  []int
+		ttyTime int64
+		gifTime int64
 	)
 	err = g.TtyPlay(input, vt, func(diff int32) (err error) {
-		delay := int(float64(diff)/g.Speed) / 10000
+		ttyTime += int64(float64(diff) / g.Speed)
+		delay := int((ttyTime-gifTime)/10000/10) * 10
+		gifTime += int64(delay) * 10000
 		if delay > 0 {
 			var img *image.Paletted
 			img, err = g.Capture(&state)

--- a/screenInfo.go
+++ b/screenInfo.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"github.com/james4k/terminal"
+)
+
+// ScreenInfo type
+type ScreenInfo struct {
+	Width         int
+	Height        int
+	Chars         []rune
+	Fcolors       []terminal.Color
+	Bcolors       []terminal.Color
+	CursorX       int
+	CursorY       int
+	CursorVisible bool
+	top           int
+	bottom        int
+	left          int
+	right         int
+}
+
+// NewScreenInfo returns ScreenInfo instance
+func NewScreenInfo() *ScreenInfo {
+	return &ScreenInfo{
+		Width:         -1,
+		Height:        -1,
+		Chars:         []rune{},
+		Fcolors:       []terminal.Color{},
+		Bcolors:       []terminal.Color{},
+		CursorX:       -1,
+		CursorY:       -1,
+		CursorVisible: false,
+		top:           -1,
+		bottom:        -1,
+		left:          -1,
+		right:         -1,
+	}
+}
+
+func (s *ScreenInfo) save(width int, height int, state *terminal.State) {
+	if s.Width != width || s.Height != height {
+		s.Width = width
+		s.Height = height
+		s.Chars = make([]rune, width*height)
+		s.Fcolors = make([]terminal.Color, width*height)
+		s.Bcolors = make([]terminal.Color, width*height)
+	}
+	for row := 0; row < s.Height; row++ {
+		for col := 0; col < s.Width; col++ {
+			ch, fg, bg := state.Cell(col, row)
+			s.Chars[row*s.Width+col] = ch
+			s.Fcolors[row*s.Width+col] = fg
+			s.Bcolors[row*s.Width+col] = bg
+		}
+	}
+	s.CursorX, s.CursorY = state.Cursor()
+	s.CursorVisible = state.CursorVisible()
+}
+
+func (s *ScreenInfo) updateRedrawRange(x int, y int) {
+	if y < s.top {
+		s.top = y
+	}
+	if s.bottom < y+1 {
+		s.bottom = y + 1
+	}
+	if x < s.left {
+		s.left = x
+	}
+	if s.right < x+1 {
+		s.right = x + 1
+	}
+}
+
+// GetRedrawRange returns redraw range.
+func (s *ScreenInfo) GetRedrawRange(width int, height int, state *terminal.State) (left int, top int, right int, bottom int) {
+
+	defer s.save(width, height, state)
+
+	if s.Width != width || s.Height != height {
+		return 0, 0, width, height
+	}
+
+	s.top = height
+	s.bottom = 0
+	s.left = width
+	s.right = 0
+
+	for row := 0; row < height; row++ {
+		for col := 0; col < width; col++ {
+			ch, fg, bg := state.Cell(col, row)
+			ch0 := s.Chars[row*width+col]
+			fg0 := s.Fcolors[row*width+col]
+			bg0 := s.Bcolors[row*width+col]
+			if ch != ch0 || fg != fg0 || bg != bg0 {
+				s.updateRedrawRange(col, row)
+			}
+		}
+	}
+	cursorVisible := state.CursorVisible()
+	cursorX, cursorY := state.Cursor()
+
+	if s.CursorVisible && !cursorVisible {
+		s.updateRedrawRange(s.CursorX, s.CursorY)
+	}
+
+	if !s.CursorVisible && cursorVisible {
+		s.updateRedrawRange(cursorX, cursorY)
+	}
+
+	if s.CursorVisible && cursorVisible && (s.CursorX != cursorX || s.CursorY != cursorY) {
+		s.updateRedrawRange(s.CursorX, s.CursorY)
+		s.updateRedrawRange(cursorX, cursorY)
+	}
+
+	return s.left, s.top, s.right, s.bottom
+}


### PR DESCRIPTION
コンソールのイメージをgifにするのに、ttyrec2gif を使わせていただきました。ありがとうございます。

短い間隔で１文字づつ表示するコマンドを実行したデータ（ ttyrec で 約6秒。128x40文字ぐらいを出力）を gif に変換すると、2秒ぐらいで描画されてしまう事象がありました。

gif のディレイ時間を計算する箇所で、 **フレーム間の時間** を100分の1秒単位に丸め（切り捨て）をしている箇所があるため、短い間隔で少しづつ表示するようなケースだと、トータルでかなり表示時間が短くなってしまうのだろうと思いました。

ディレイ時間を **開始からの累計時間** で計算するようにすると、切り捨て誤差が少なくなるだろうと思い、試しに累計時間を 100分の1秒単位（アニメgifの最大精度）で丸めてディレイ時間を計算した場合、非常に多くのフレームが必要となり、またgifの表示時間も実際よりもかなり遅くなってしまいました。

累計時間を 10分の1秒単位で丸めてディレイ時間を計算したころ、ほどほどのスピードで表示されるようです。

ただし、それでもフレーム数が増える関係で、gif データが大きくなってしまう副作用もあります。

そこで、gifのフレームを毎回ターミナル全体ではなく、変更された文字のある範囲だけに絞るような対応も入れてみました。（ `terminal.State` のコピーが作れればよかったのですが、よくわからなかったので力業でデータを保存するようにしてしてしまいました ）