### PR TITLE
fix broken glyph

### DIFF
--- a/capture.go
+++ b/capture.go
@@ -40,7 +40,7 @@ func (g *GifGenerator) Capture(state *terminal.State) (paletted *image.Paletted,
 	c.SetFontSize(fontSize)
 	c.SetFont(font)
 	c.SetDst(paletted)
-	c.SetClip(paletted.Bounds())
+	c.SetClip(image.Rect(0, 0, g.Col*int(fb.Max.X-fb.Min.X)+10, g.Row*int(fb.Max.Y-fb.Min.Y)+10))
 	for row := 0; row < g.Row; row++ {
 		for col := 0; col < g.Col; col++ {
 			ch, fg, bg := state.Cell(col, row)


### PR DESCRIPTION
すみません、先日 PR #6 を送った者なのですが、問題があったので再度送らせていただきます。

おそらく `freetype` の問題なのではないかと思うのですが、 `freetype.Context` の `SetClip()` に小さい領域を指定すると、領域の端あたり（？）にゴミが表示されるようです（1 文字づつ表示するようなケースだと目立ちます）

![before](https://user-images.githubusercontent.com/15214393/82143277-a2547780-987d-11ea-9c51-703df2e9c182.gif)

GIF のフレームの `image` は小さいまま、 `SetClip()` に渡す範囲だけ大きくするとゴミがでません。

![after](https://user-images.githubusercontent.com/15214393/82143274-a1234a80-987d-11ea-8331-3ef72ec0ab13.gif)

あまりキレイな修正方法ではありませんが…。

お手数をおかけして申し訳ありませんが、ご確認願います。